### PR TITLE
[F001] Populate author biography from API

### DIFF
--- a/app/models/author.js
+++ b/app/models/author.js
@@ -3,6 +3,7 @@ import Publisher from './publisher';
 import { on } from '@ember/object/evented';
 
 export default Publisher.extend({
+  biography: DS.attr('string'),
   books: DS.hasMany('book'),
 
   loadedAt: on('didLoad', function() {

--- a/app/templates/author.hbs
+++ b/app/templates/author.hbs
@@ -1,6 +1,8 @@
 <h3>{{model.name}}</h3>
 
-<strong>Biography</strong>: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+{{#if model.biography}}
+  <strong>Biography</strong>: {{model.biography}}
+{{/if}}
 
 <h4>Published titles:</h4>
 <ul>


### PR DESCRIPTION
Small PR to populate author biographies from the backend API

REQUIRES: https://github.com/scasagrande/bookstore-api/pull/2